### PR TITLE
Add optional event param to IInfoboxActions.eventhandler()

### DIFF
--- a/scripts/MicrosoftMaps/Microsoft.Maps.d.ts
+++ b/scripts/MicrosoftMaps/Microsoft.Maps.d.ts
@@ -308,7 +308,7 @@ declare module Microsoft.Maps {
         label: string;
 
         /** The function to call when the label is clicked.  */
-        eventHandler: () => void;
+        eventHandler: (eventArg?: MouseEvent) => void;
     }
 
     /** An object that contains information about an infobox event. **/


### PR DESCRIPTION
When debugging in JavaScript you can see that a MouseEvent object is being passed as the lone argument to the event handler, so it should be made accessible to the developer.