### PR TITLE
Update Directions.d.ts

### DIFF
--- a/scripts/MicrosoftMaps/Modules/Directions.d.ts
+++ b/scripts/MicrosoftMaps/Modules/Directions.d.ts
@@ -613,4 +613,5 @@ declare module Microsoft.Maps {
          * @returns The handler id.
          */
         export function addThrottledHandler(target: Directions.DirectionsManager, eventName: string, handler: (eventArg?: Directions.IDirectionsEventArgs | Directions.IDirectionsErrorEventArgs) => void, throttleInterval: number): IHandlerId;
+    }
 }


### PR DESCRIPTION
Missing closing bracket for declare module Microsoft.Maps:
Error	TS1005	'}' expected.