### PR TITLE
Added the value "birdseye" to the MapTypeId enum

### DIFF
--- a/scripts/MicrosoftMaps/Microsoft.Maps.d.ts
+++ b/scripts/MicrosoftMaps/Microsoft.Maps.d.ts
@@ -47,6 +47,9 @@ declare module Microsoft.Maps {
         /** The aerial map type which uses top-down satellite & airplane imagery. */
         aerial,
 
+        /** High resolution aerial imagery taken at 45 degrees to the ground, from 4 different directions. */
+        birdseye,
+
         /** A darker version of the road maps. */
         canvasDark,
 


### PR DESCRIPTION
Added birdseye to the MapTypeId enum to reflect the Birdseye view availability in the public release of the Bing Maps V8 Web Control.
The description for the enum value was taken from [MSDN](https://msdn.microsoft.com/en-us/library/mt712700.aspx).